### PR TITLE
Add role-based UI gating and automatic data loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,11 +95,11 @@
 <main class="container my-4">
 
   <!-- APP -->
-  <section id="app" class="d-none">
+  <section id="app" class="app-shell d-none">
     <ul class="nav nav-tabs" id="mainTabs" role="tablist">
-      <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabDash" type="button">Dashboard</button></li>
-      <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabOT" type="button">Budget de fonctionnement (OT)</button></li>
-      <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabOI" type="button">Budget d’investissement (OI)</button></li>
+      <li class="nav-item role-admin-only" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabDash" type="button">Dashboard</button></li>
+      <li class="nav-item role-admin-only" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabOT" type="button">Budget de fonctionnement (OT)</button></li>
+      <li class="nav-item role-admin-only" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabOI" type="button">Budget d’investissement (OI)</button></li>
       <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tabLaunch" type="button">PPA</button></li>
   <!-- Dossiers en réalisation tab removed -->
     </ul>
@@ -107,7 +107,7 @@
     <div class="tab-content border-start border-end border-bottom p-3 bg-white shadow-sm">
 
       <!-- DASHBOARD -->
-      <div id="tabDash" class="tab-pane fade show active">
+      <div id="tabDash" class="tab-pane fade show active role-admin-only">
         <header class="container py-3"><h2 class="mb-0">Tableau de bord</h2></header>
           <section id="dashboard" class="container mb-4">
             <div class="row g-3">
@@ -186,7 +186,7 @@
       </div>
 
       <!-- OI -->
-      <div id="tabOI" class="tab-pane fade">
+      <div id="tabOI" class="tab-pane fade role-admin-only">
         <div class="d-flex align-items-center mb-3">
           <h5 class="m-0">Budget OI — Données locales : <span id="oiYear"></span></h5>
           <div class="ms-auto d-flex gap-2">
@@ -254,7 +254,7 @@
       </div>
 
       <!-- OT -->
-      <div id="tabOT" class="tab-pane fade show active">
+      <div id="tabOT" class="tab-pane fade role-admin-only">
 
         <div class="d-flex align-items-center mb-3">
           <h5 class="m-0">Budget OT — Données locales : <span id="otYear"></span></h5>
@@ -448,10 +448,10 @@
   })();
 </script>
 
-<div id="globalLoader" style="display:none;position:fixed;inset:0;z-index:2000;background:rgba(255,255,255,.7)">
-  <div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);" class="text-center">
-    <div class="spinner-border" role="status" aria-hidden="true"></div>
-    <div class="mt-2 small text-muted">Chargement…</div>
+<div id="globalLoader" class="app-loader d-none" aria-hidden="true">
+  <div class="app-loader__content text-center">
+    <div class="spinner-border text-primary" role="status" aria-hidden="true"></div>
+    <div class="loader-message mt-3">Chargement…</div>
   </div>
 </div>
 

--- a/src/excel.js
+++ b/src/excel.js
@@ -1,8 +1,12 @@
 // ====== Page 2 : Données locales persistantes (sans serveur) ======
-// Session guard: redirect to login if there is no active session
+// Session guard handled in main app; no redirect here to keep embedded login flow.
 try{
   const s = JSON.parse(localStorage.getItem('as_session')||'null');
-  if(!s){ window.location.href = 'login.html'; }
+  if(!s){
+    document.addEventListener('DOMContentLoaded', ()=>{
+      try{ if(globalThis.App && App.Auth && typeof App.Auth.initLogin === 'function'){ App.Auth.initLogin(); } }catch(err){ console.warn(err); }
+    }, {once:true});
+  }
 }catch(e){}
 
 let fileHandle = null; // PPA handle
@@ -450,8 +454,34 @@ function exportExcel(){
 
 
 // Global loader helpers
-function showLoader(){ try{ document.getElementById('globalLoader').style.display='block'; }catch(e){} }
-function hideLoader(){ try{ document.getElementById('globalLoader').style.display='none'; }catch(e){} }
+function showLoader(message){
+  try{
+    if(globalThis.AppLoader){
+      globalThis.AppLoader.show(message);
+    }else{
+      const el = document.getElementById('globalLoader');
+      if(el){
+        const msg = el.querySelector('.loader-message');
+        if(msg) msg.textContent = message || 'Chargement…';
+        el.classList.remove('d-none');
+        requestAnimationFrame(()=> el.classList.add('active'));
+      }
+    }
+  }catch(e){}
+}
+function hideLoader(){
+  try{
+    if(globalThis.AppLoader){
+      globalThis.AppLoader.hide();
+    }else{
+      const el = document.getElementById('globalLoader');
+      if(el){
+        el.classList.remove('active');
+        setTimeout(()=> el.classList.add('d-none'), 320);
+      }
+    }
+  }catch(e){}
+}
 
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -7,3 +7,56 @@ body{ background:#f6f7fb; }
 .table td.small{ max-width:360px; }
 .kpis .card .display-6{ font-weight:700; }
 .modal-xl{ --bs-modal-width: 1100px; }
+
+.login-screen{
+  min-height:100vh;
+  background:#f5f7fb;
+  transition:opacity .4s ease, visibility .4s ease;
+}
+.login-screen.screen-hidden{
+  opacity:0;
+  visibility:hidden;
+  pointer-events:none;
+}
+
+.app-shell{
+  opacity:0;
+  transition:opacity .4s ease;
+}
+.app-shell.app-visible{
+  opacity:1;
+}
+
+.app-loader{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:2000;
+  background:rgba(246,247,251,.85);
+  backdrop-filter:blur(2px);
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .3s ease;
+}
+.app-loader.active{
+  opacity:1;
+  pointer-events:auto;
+}
+.app-loader__content{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:0.75rem;
+  padding:1.5rem 2rem;
+  background:rgba(255,255,255,0.9);
+  border-radius:1rem;
+  box-shadow:0 1.5rem 3rem rgba(15,23,42,0.12);
+}
+.app-loader .loader-message{
+  font-size:.875rem;
+  color:#495057;
+}
+
+body.role-user .role-admin-only{ display:none !important; }


### PR DESCRIPTION
## Summary
- default to the embedded login experience and hide admin-only navigation for non-admin roles with a smoother fade transition
- add a reusable loader overlay and expose it to Excel helpers so login-to-app transitions surface progress feedback
- bootstrap OT/OI/PPA datasets from the Data/ directory on login so dashboards populate automatically without manual imports

## Testing
- Manual via browser (login screen)


------
https://chatgpt.com/codex/tasks/task_e_68e565adbf6483339312f7a1ec5bf05c